### PR TITLE
Forcing ticket list update whenever a ticket had a status change

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,7 +143,10 @@
       'getTicketFields.done': 'processTicketFields',
       'searchExternalID.done': function(data) {
         this.listProjects(data || {});
-      }
+      },
+
+      // Zendesk Events
+      'ticket.status.changed': 'ticketStatusChangedHandler'
     },
     //end events
     requests: {
@@ -685,6 +688,11 @@
         this.processData();
       });
 
+    },
+    // Triggered whenever a ticket had a status change
+    ticketStatusChangedHandler: function(){
+      // Forces a list update to fetch new ticket status
+      this.updateList();
     }
   };
 }());


### PR DESCRIPTION
The ticket list wouldn't update status labels whenever a ticket had a status change. With this fix the list immediately updates, showing the ticket's new status.