### PR TITLE
bugfix: isSolvable is always false

### DIFF
--- a/app.js
+++ b/app.js
@@ -437,6 +437,7 @@
       var nextPage = 1;
       var btnClicked = (data.type === 'click');
       if (!btnClicked) {
+        this.isSolvable = true; // Resets solvable status before building Ticket List
         _.each(data.tickets, buildTicketList, this);
         if (data.next_page !== null) {
           nextPage = nextPage + 1;
@@ -458,7 +459,7 @@
       }
     },
     parentSolve: function() {
-      //enable solve and if this.isSolvavle is false disable solve
+      //enable solve and if this.isSolvable is false disable solve
       this.ticketFields('status').options('solved').enable();
       //if this is a child ticket stop and exit function
       var hasProjectChildTag = _.include(this.ticket().tags(), 'project_child');


### PR DESCRIPTION
`isSolvable` is set as `true` when the app starts. Once it is set as `false`, it would **never** be set as `true` again. This way, if the user have the parent ticket open in Zendesk and solve child tickets, the option to solve the parent would only be re-enabled if the app was reloaded.

I've added a line to re-set `this.isSolvable = true;` every time before building ticket list. The `buildTicketList()` function will set `isSolvable` back to `false` if any child tickets are not solved or close.