### PR TITLE
feat: take over properties from the parent ticket

### DIFF
--- a/app.js
+++ b/app.js
@@ -382,10 +382,10 @@
     duplicateCustomFieldsValues: function(ticketObjectForApi) {
       var me = this;
       // Read out the ids for the desired custom fields to copy.
-      var customFieldIdsToCopySetting = me.setting('customFieldIdsToCopy') + '',
+      var customFieldIdsToCopySetting = me.setting('customFieldIdsToCopy') || '',
           customFieldIdsToCopy = customFieldIdsToCopySetting.match(/\b\d+\b/g);
       // Done if there are none.
-      if (!customFieldIdsToCopy.length) {
+      if (!(customFieldIdsToCopy && customFieldIdsToCopy.length)) {
         return;
       }
       

--- a/app.js
+++ b/app.js
@@ -344,8 +344,8 @@
     switchToRequester: function() {
       var newSubject = this.ticket().subject();
       var currentForm = this.ticket().form().id();
-      var ticketType = this.getTicketType(this.ticket().type());
-      var ticketPri = this.getTicketPri(this.ticket().priority());
+      var ticketType = this.getTicketTypes(this.setting('defaultTicketType') || this.ticket().type());
+      var ticketPri = this.getTicketPrios(this.setting('defaultTicketPriority') || this.ticket().priority());
       if (this.prependSubject) {
         newSubject = 'Project-' + this.ticket().id() + ' ' + newSubject;
       }
@@ -387,19 +387,19 @@
       this.currentTicketformID = this.ticket().form().id() || this.defaultTicketFormID;
       this.projectNameFieldExist();
     },
-    getTicketType: function(type){
-    var types = [{'title': 'Question', 'value': 'question'},{'title': 'Incident', 'value': 'incident'},{'title': 'Problem', 'value': 'problem'},{'title': 'Task', 'value': 'task'}];
+    getTicketTypes: function(selectedType){
+    var types = [{'title': '-', 'value': ''},{'title': 'Question', 'value': 'question'},{'title': 'Incident', 'value': 'incident'},{'title': 'Problem', 'value': 'problem'},{'title': 'Task', 'value': 'task'}];
     types.forEach(function(t){
-      if(t.value === type){
+      if(t.value === selectedType){
         t.selected = true;
       }
     });
     return types;
   },
-  getTicketPri: function(type){
-    var pri = [{'title': 'Low', 'value': 'low'},{'title': 'Normal', 'value': 'normal'},{'title': 'High', 'value': 'high'},{'title': 'Urgent', 'value': 'urgent'}];
+  getTicketPrios: function(selectedPrio){
+    var pri = [{'title': '-', 'value': ''},{'title': 'Low', 'value': 'low'},{'title': 'Normal', 'value': 'normal'},{'title': 'High', 'value': 'high'},{'title': 'Urgent', 'value': 'urgent'}];
     pri.forEach(function(t){
-      if(t.value === type){
+      if(t.value === selectedPrio){
         t.selected = true;
       }
     });
@@ -599,8 +599,8 @@
       }
     },
     switchToBulk: function() {
-      var ticketType = this.getTicketType(this.ticket().type());
-      var ticketPri = this.getTicketPri(this.ticket().priority());
+      var ticketType = this.getTicketTypes(this.setting('defaultTicketType') || this.ticket().type());
+      var ticketPri = this.getTicketPrios(this.setting('defaultTicketPriority') || this.ticket().priority());
       var currentForm = this.ticket().form().id();
       this.switchTo('multicreate', {
         ticketForm: this.ticketForms,

--- a/app.js
+++ b/app.js
@@ -288,13 +288,19 @@
       this.$('#zendeskGroup').autocomplete({
         minLength: 3,
         source: this.groupDrop,
-        focus: function(event, ui) {
-          self.$("#zendeskGroup").val(ui.item.label);
+        select: function(event, ui) {
+          self.$("#assigneeName").val(ui.item.label);
+          self.$("#assigneeId").val(ui.item.value);
           return false;
         },
-        select: function(event, ui) {
-          self.$("#zendeskGSelect").val(ui.item.value);
-          return false;
+        change: function(event, ui) {
+          if (_.isNull(ui.item)) {
+            self.$("#zendeskGroup").val('');
+            self.$("#zendeskGSelect").val('');
+          } else {
+            self.$("#zendeskGroup").val(ui.item.label);
+            self.$("#zendeskGSelect").val(ui.item.value);
+          }
         }
       }, this);
     },
@@ -356,7 +362,6 @@
         ticketForm: this.ticketForms,
         currentForm: currentForm,
         email: this.ticket().requester().email(),
-        groups: this.groupDrop,
         subject: newSubject,
         desc: this.ticket().description(),
         ticketType: ticketType,
@@ -616,7 +621,6 @@
       this.$('button.displayForm').show();
       this.$('button.displayMultiCreate').hide();
       this.autocompleteRequesterEmail();
-      this.autocompleteGroup();
       this.$('#zendeskForm').change();
       this.$('#dueDate').val(this.currentTicket.ticket.due_at).datepicker({ dateFormat: 'yy-mm-dd' });
       if(this.$('#zenType').val() === 'task'){

--- a/app.js
+++ b/app.js
@@ -369,6 +369,7 @@
         fieldListArray.forEach(function(field){
           rootTicket.ticket.custom_fields[field.name] = field.value;
         }, this);
+        this.duplicateCustomFieldsValues(rootTicket.ticket);
         var childCall = JSON.stringify(rootTicket);
         this.ajax('createTicket', childCall);
       }, this);
@@ -377,6 +378,27 @@
       var currentTags = this.ticket().tags();
       this.putTicketData(currentTags, 'project_parent', 'add', ticket.id());
 
+    },
+    duplicateCustomFieldsValues: function(ticketObjectForApi) {
+      var me = this;
+      // Read out the ids for the desired custom fields to copy.
+      var customFieldIdsToCopySetting = me.setting('customFieldIdsToCopy') + '',
+          customFieldIdsToCopy = customFieldIdsToCopySetting.match(/\b\d+\b/g);
+      // Done if there are none.
+      if (!customFieldIdsToCopy.length) {
+        return;
+      }
+      
+      // Copy the value of each (existing) custom field. Don't overwrite.
+      if (!_.has(ticketObjectForApi, 'custom_fields')) {
+        ticketObjectForApi.custom_fields = {};
+      }
+      customFieldIdsToCopy.forEach(function(customFieldIdToCopy){
+        if (_.has(ticketObjectForApi.custom_fields, customFieldIdToCopy)) {
+          return;
+        }
+        ticketObjectForApi.custom_fields[customFieldIdToCopy] = me.ticket().customField('custom_field_' + customFieldIdToCopy + '');
+      });
     },
     switchToRequester: function() {
       var newSubject = this.ticket().subject();

--- a/app.js
+++ b/app.js
@@ -389,10 +389,25 @@
       if (this.appendSubject) {
         newSubject = newSubject + ' Project-' + this.ticket().id();
       }
+      var assigneeId, assigneeName, groupId, groupName;
+      if (this.setting('prefillAssignee')) {
+        if (this.ticket().assignee().user()) {
+          assigneeName = this.ticket().assignee().user().name();
+          assigneeId = this.ticket().assignee().user().id();
+        }
+        if (this.ticket().assignee().group()) {
+          groupName = this.ticket().assignee().group().name();
+          groupId = this.ticket().assignee().group().id();
+        }
+      }
       this.switchTo('requester', {
         ticketForm: this.ticketForms,
         currentForm: currentForm,
         email: this.ticket().requester().email(),
+        assigneeName: assigneeName,
+        assigneeId: assigneeId,
+        groupName: groupName,
+        groupId: groupId,
         subject: newSubject,
         desc: this.ticket().description(),
         ticketType: ticketType,
@@ -639,10 +654,19 @@
       var ticketType = this.getTicketTypes(this.setting('defaultTicketType') || this.ticket().type());
       var ticketPri = this.getTicketPrios(this.setting('defaultTicketPriority') || this.ticket().priority());
       var currentForm = this.ticket().form().id();
+      var assigneeId, assigneeName;
+      if (this.setting('prefillAssignee')) {
+        if (this.ticket().assignee().user()) {
+          assigneeName = this.ticket().assignee().user().name();
+          assigneeId = this.ticket().assignee().user().id();
+        }
+      }
       this.switchTo('multicreate', {
         ticketForm: this.ticketForms,
         currentForm: currentForm,
         email: this.ticket().requester().email(),
+        assigneeName: assigneeName,
+        assigneeId: assigneeId,
         groups: this.groupDrop,
         subject: this.ticket().subject(),
         desc: this.ticket().description(),

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,9 @@
 		"type": "multiline",
 		"required": false
 	}, {
+		"name": "prefillAssignee",
+		"type": "checkbox"
+	}, {
 		"name": "defaultTicketType",
 		"type": "text",
                 "required": false

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,14 @@
 		"name": "settingsMap",
 		"type": "multiline",
 		"required": false
+	}, {
+		"name": "defaultTicketType",
+		"type": "text",
+                "required": false
+	}, {
+		"name": "defaultTicketPriority",
+		"type": "text",
+                "required": false
 	}],
 	"frameworkVersion": "1.0",
 	"location": "ticket_sidebar",

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,10 @@
 		"name": "defaultTicketPriority",
 		"type": "text",
                 "required": false
+	}, {
+		"name": "customFieldIdsToCopy",
+		"type": "text",
+                "required": false
 	}],
 	"frameworkVersion": "1.0",
 	"location": "ticket_sidebar",

--- a/templates/multicreate.hdbs
+++ b/templates/multicreate.hdbs
@@ -22,6 +22,16 @@
       <input type="text" required placeholder="Requester Name" name="userName" id="userName" style="width: 196px;" value=""/>
     </div>
 
+    <div class="control-group">
+      <label for="assigneeId">Assignee Name</label>
+      <input type="text" placeholder="Assignee" name="assigneeName" id="assigneeName" style="width: 196px"/>
+    </div>
+
+    <div class="control-group" style="display: none;">
+      <label for="assigneeId">Assignee Id</label>
+      <input type="text" placeholder="Assignee id" name="assigneeId" id="assigneeId"/>
+    </div>
+
 		<div class="control-group">
 			<div class="select" required = "required">
 		  	<label for="zendeskGSelect">Groups</label>

--- a/templates/multicreate.hdbs
+++ b/templates/multicreate.hdbs
@@ -37,8 +37,7 @@
     	<div class="select" required = "required">
       	<label for="zenType">Ticket Type</label>
         <select id="zenType" required name="zenType" onchange style="width: auto;" size="1">
-        	<option value="">-</option>
-        	{{#each ticketType}}
+          {{#each ticketType}}
             <option value="{{value}}" {{#if selected}} selected="selected" {{/if}}>{{title}}</option>
           {{/each}}
       	</select>
@@ -54,7 +53,6 @@
 			<div class="select" required = "required">
       	<label for="zenPri">Ticket Priority</label>
         <select id="zenPri" required name="zenPri" onchange style="width: auto;" size="1">
-        	<option value="">-</option>
           {{#each ticketPri}}
             <option value="{{value}}" {{#if selected}} selected="selected" {{/if}}>{{title}}</option>
           {{/each}}

--- a/templates/multicreate.hdbs
+++ b/templates/multicreate.hdbs
@@ -24,12 +24,12 @@
 
     <div class="control-group">
       <label for="assigneeId">Assignee Name</label>
-      <input type="text" placeholder="Assignee" name="assigneeName" id="assigneeName" style="width: 196px"/>
+      <input type="text" placeholder="Assignee" name="assigneeName" id="assigneeName" style="width: 196px" value="{{assigneeName}}"/>
     </div>
 
     <div class="control-group" style="display: none;">
       <label for="assigneeId">Assignee Id</label>
-      <input type="text" placeholder="Assignee id" name="assigneeId" id="assigneeId"/>
+      <input type="text" placeholder="Assignee id" name="assigneeId" id="assigneeId" value="{{assigneeId}}"/>
     </div>
 
 		<div class="control-group">

--- a/templates/requester.hdbs
+++ b/templates/requester.hdbs
@@ -34,7 +34,6 @@
       <div class="select" required = "required">
         <label for="zenType">Ticket Type</label>
         <select id="zenType" required name="zenType" onchange style="width: auto;" size="1">
-          <option value="">-</option>
           {{#each ticketType}}
             <option value="{{value}}" {{#if selected}} selected="selected" {{/if}}>{{title}}</option>
           {{/each}}
@@ -51,7 +50,6 @@
       <div class="select" required = "required">
         <label for="zenPri">Ticket Priority</label>
         <select id="zenPri" required name="zenPri" onchange style="width: auto;" size="1">
-          <option value="">-</option>
           {{#each ticketPri}}
             <option value="{{value}}" {{#if selected}} selected="selected" {{/if}}>{{title}}</option>
           {{/each}}

--- a/templates/requester.hdbs
+++ b/templates/requester.hdbs
@@ -22,12 +22,12 @@
 
     <div class="control-group">
       <label for="zendeskGroup">Group</label>
-      <input type="text" placeholder="Group Name" name="zendeskGroup" id="zendeskGroup" style="width: 196px;" value=""/>
+      <input type="text" placeholder="Group Name" name="zendeskGroup" id="zendeskGroup" style="width: 196px;" value="{{groupName}}"/>
     </div>
 
     <div class="control-group" style="display: none;">
-      <label for="zendeskSelect">Group Id</label>
-      <input type="text" required placeholder="Group id" name="zendeskSelect" id="zendeskSelect" value=""/>
+      <label for="zendeskGSelect">Group Id</label>
+      <input type="text" required placeholder="Group id" name="zendeskGSelect" id="zendeskGSelect" value="{{groupId}}"/>
     </div>
 
     <div class="control-group">

--- a/templates/requester.hdbs
+++ b/templates/requester.hdbs
@@ -22,12 +22,12 @@
 
     <div class="control-group">
       <label for="assigneeId">Assignee Name</label>
-      <input type="text" placeholder="Assignee" name="assigneeName" id="assigneeName" style="width: 196px"/>
+      <input type="text" placeholder="Assignee" name="assigneeName" id="assigneeName" style="width: 196px" value="{{assigneeName}}"/>
     </div>
 
     <div class="control-group" style="display: none;">
       <label for="assigneeId">Assignee Id</label>
-      <input type="text" placeholder="Assignee id" name="assigneeId" id="assigneeId"/>
+      <input type="text" placeholder="Assignee id" name="assigneeId" id="assigneeId" value="{{assigneeId}}"/>
     </div>
 
     <div class="control-group">

--- a/templates/requester.hdbs
+++ b/templates/requester.hdbs
@@ -21,6 +21,16 @@
     </div>
 
     <div class="control-group">
+      <label for="assigneeId">Assignee Name</label>
+      <input type="text" placeholder="Assignee" name="assigneeName" id="assigneeName" style="width: 196px"/>
+    </div>
+
+    <div class="control-group" style="display: none;">
+      <label for="assigneeId">Assignee Id</label>
+      <input type="text" placeholder="Assignee id" name="assigneeId" id="assigneeId"/>
+    </div>
+
+    <div class="control-group">
       <label for="zendeskGroup">Group</label>
       <input type="text" placeholder="Group Name" name="zendeskGroup" id="zendeskGroup" style="width: 196px;" value="{{groupName}}"/>
     </div>

--- a/translations/en.json
+++ b/translations/en.json
@@ -18,6 +18,14 @@
       "settingsMap" : {
         "label": "Preset template mappings",
         "helpText": "Settings for ticket types to set groups for bulk ticket creates. It needs to be in a JSON format"
+      },
+      "defaultTicketType" : {
+        "label": "Default ticket type",
+        "helpText": "Instead of taking over the ticket type from the current ticket, use this type by default. Empty (to take over), or one of: question, incident, problem, or task."
+      },
+      "defaultTicketPriority" : {
+        "label": "Default ticket priority",
+        "helpText": "Instead of taking over the ticket priority from the current ticket, use this priority by default. Empty (to take over), or one of: low, normal, high, urgent."
       }
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -30,6 +30,10 @@
       "defaultTicketPriority" : {
         "label": "Default ticket priority",
         "helpText": "Instead of taking over the ticket priority from the current ticket, use this priority by default. Empty (to take over), or one of: low, normal, high, urgent."
+      },
+      "customFieldIdsToCopy" : {
+        "label": "Copy values from Custom Fields",
+        "helpText": "(Optionally) copy the values from the Custom Fields with these ID(s) to the new ticket(s). Comma separated."
       }
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -19,6 +19,10 @@
         "label": "Preset template mappings",
         "helpText": "Settings for ticket types to set groups for bulk ticket creates. It needs to be in a JSON format"
       },
+      "prefillAssignee" : {
+        "label": "Prefill assignee and group",
+        "helpText": "Prefill the assignee and group fields in the creation form, taken over from the current ticket."
+      },
       "defaultTicketType" : {
         "label": "Default ticket type",
         "helpText": "Instead of taking over the ticket type from the current ticket, use this type by default. Empty (to take over), or one of: question, incident, problem, or task."


### PR DESCRIPTION
Added some features regarding taking over properties from the parent ticket to the child ticket(s). I.e.:
* Option to copy the values from specific custom fields.
* Possibility to set the assignee of a ticket. (Optionally prefilled with the parent ticket's assignee.)
* Option to set a default ticket type and prio for a ticket, instead of taking over the parent ticket's.

(I've implemented these features because my company needs them.)